### PR TITLE
24.02.17) [Feat]: 카테고리별 Marker 필터링 기능 구현

### DIFF
--- a/AVIRO/Model/HomeViewModel/MarkerModel.swift
+++ b/AVIRO/Model/HomeViewModel/MarkerModel.swift
@@ -22,6 +22,16 @@ enum CategoryType {
     case Bread
     case Coffee
     case Restaurant
+    
+    init?(with value: String) {
+        switch value {
+        case "식당": self = .Restaurant
+        case "카페": self = .Coffee
+        case "술집": self = .Bar
+        case "빵집": self = .Bread
+        default: return nil
+        }
+    }
 }
 
 // MARK: - Map Icon

--- a/AVIRO/Scene/Feature/Home/ViewController/HomeViewController.swift
+++ b/AVIRO/Scene/Feature/Home/ViewController/HomeViewController.swift
@@ -485,7 +485,6 @@ extension HomeViewController: HomeViewProtocol {
 
     /// 최초 load markers
     func loadMarkers(with markers: [NMFMarker]) {
-        
         markers.forEach {
             $0.mapView = naverMapView
         }
@@ -494,6 +493,17 @@ extension HomeViewController: HomeViewProtocol {
     /// star button clicked
     func afterLoadStarButton(with noStars: [NMFMarker]) {
         noStars.forEach {
+            $0.mapView = nil
+        }
+    }
+    
+    // MARK: - Marker Update
+    func afterClickedCategoryModel(showMarkers: [NMFMarker], hideMarkers: [NMFMarker]) {
+        showMarkers.forEach {
+            $0.mapView = naverMapView
+        }
+        
+        hideMarkers.forEach {
             $0.mapView = nil
         }
     }
@@ -1322,7 +1332,6 @@ extension HomeViewController: UICollectionViewDataSource {
             
         cell.whenCategoryButtonTapped = { [weak self] (selectedType, selectedState) in
             self?.updateSearchTextField(with: selectedType)
-            
             self?.presenter.whenUpdateType = (selectedType, selectedState)
         }
         

--- a/AVIRO/Scene/Feature/Home/ViewController/HomeViewController.swift
+++ b/AVIRO/Scene/Feature/Home/ViewController/HomeViewController.swift
@@ -1108,7 +1108,12 @@ extension HomeViewController: UITextFieldDelegate {
             self?.navigationController?.pushViewController(vc, animated: false)
             
             textField.leftView?.isHidden = false
-            textField.placeholder = Text.searchPlaceHolder.rawValue
+            
+            if self?.selectedCategoriesPlaceHolder.isEmpty ?? false {
+                textField.placeholder = Text.searchPlaceHolder.rawValue
+            } else {
+                textField.placeholder = self?.selectedCategoriesPlaceHolder.joined(separator: ", ")
+            }
         }
     }
     
@@ -1118,7 +1123,12 @@ extension HomeViewController: UITextFieldDelegate {
     
     private func afterSearchFieldInit() {
         searchTextField.text = ""
-        searchTextField.placeholder = Text.searchPlaceHolder.rawValue
+        
+        if selectedCategoriesPlaceHolder.isEmpty {
+            searchTextField.placeholder = Text.searchPlaceHolder.rawValue
+        } else {
+            searchTextField.placeholder = selectedCategoriesPlaceHolder.joined(separator: ", ")
+        }
     }
 }
 


### PR DESCRIPTION
- Category Type별 클릭될 때 선택된 type배열을 통해 숨길 marker, 보여질 marker 배열을 따로 관리 후 적용
- 개별 클릭해서 Category Type을 해제하거나 X 버튼을 통해 해제할 때 만들어둔 배열 초기화 및 전체 marker를 naverMapView에 다시 참조 적용
- 해당 로직 중간에 북마크 기능을 활성화 하고 있으면 로직이 꼬이는 현상 발견
    - 해제를 하거나 선택할때 중간 중간 star image 남겨지는 현상
- Star State를 새롭게 변수로 생성해서 Star 변수가 활성화되어있으면 배열만 저장하고 UI 업데이트는 따로 진행 X
- 북마크가 켜져있는 상황이 우선수위가 카테고리 클릭으로 보여질 우선순위보다 더 높음